### PR TITLE
Handles CAS v3 protocol

### DIFF
--- a/cas/backends.py
+++ b/cas/backends.py
@@ -37,7 +37,15 @@ def _verify_cas1(ticket, service):
 
 
 def _verify_cas2(ticket, service):
-    """Verifies CAS 2.0+ XML-based authentication ticket.
+    return _internal_verify_cas(ticket, service, 'proxyValidate')
+
+
+def _verify_cas3(ticket, service):
+    return _internal_verify_cas(ticket, service, 'p3/proxyValidate')
+
+
+def _internal_verify_cas(ticket, service, suffix):
+    """Verifies CAS 2.0 and 3.0 XML-based authentication ticket.
 
     Returns username on success and None on failure.
     """
@@ -51,7 +59,7 @@ def _verify_cas2(ticket, service):
     if settings.CAS_PROXY_CALLBACK:
         params['pgtUrl'] = settings.CAS_PROXY_CALLBACK
 
-    url = (urljoin(settings.CAS_SERVER_URL, 'proxyValidate') + '?' +
+    url = (urljoin(settings.CAS_SERVER_URL, suffix) + '?' +
            urlencode(params))
 
     page = urlopen(url)
@@ -135,7 +143,7 @@ def verify_proxy_ticket(ticket, service):
     finally:
         page.close()
 
-_PROTOCOLS = {'1': _verify_cas1, '2': _verify_cas2}
+_PROTOCOLS = {'1': _verify_cas1, '2': _verify_cas2, '3': _verify_cas3}
 
 if settings.CAS_VERSION not in _PROTOCOLS:
     raise ValueError('Unsupported CAS_VERSION %r' % settings.CAS_VERSION)


### PR DESCRIPTION
Replacing: https://github.com/kstateome/django-cas/pull/32.

This is a very simple implementation to handle the CAS protocol v3 (extra attributes returned in the XML payload). The callback function must be used to deal with the extra attributes received: `tree[0][1].getchildren()`.
The `CAS_VERSION` can now be set to 3 to change the endpoint used by the CAS server and to retrieve the user attributes.

Although I tested this change, I'm a newbie in Python. Just let me know if something is wrong.