### PR TITLE
Allow Forcing Service URL over HTTPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - DJANGO_VERSION=Django==1.5
   - DJANGO_VERSION=Django==1.6
   - DJANGO_VERSION=Django==1.7
+  - DJANGO_VERSION=Django==1.8
 
 # command to install dependencies
 install:

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This is [K-State&#39;s fork](https://github.com/kstateome/django-cas) of [the or
 This project is registered on PyPi as django-cas-client.  To install::
 
     pip install django-cas-client==1.1.2
-    
-    
+
+
 ### Add to URLs
 
 Add the login and logout patterns to your main URLS conf.
@@ -34,9 +34,9 @@ Set your CAS server URL
 Add cas to middleware classes
 
     'cas.middleware.CASMiddleware',
-    
 
-### Add authentication backends 
+
+### Add authentication backends
 
     AUTHENTICATION_BACKENDS = (
         'django.contrib.auth.backends.ModelBackend',
@@ -138,6 +138,9 @@ Then, add the ``gateway`` decorator to a view:
 To show a custom forbidden page, set ``CAS_CUSTOM_FORBIDDEN`` to a ``path.to.some_view``.  Otherwise,
 a generic ``HttpResponseForbidden`` will be returned.
 
+## Require SSL login
+
+To force the service url to always target HTTPS, set ``CAS_FORCE_SSL_SERVICE_URL`` to ``True``.
 
 ## Proxy Tickets
 

--- a/cas/__init__.py
+++ b/cas/__init__.py
@@ -18,6 +18,7 @@ _DEFAULTS = {
     'CAS_RESPONSE_CALLBACKS': None,
     'CAS_CUSTOM_FORBIDDEN': None,
     'CAS_PGT_FETCH_WAIT': True,
+    'CAS_FORCE_SSL_SERVICE_URL': False,
 }
 
 for key, value in _DEFAULTS.items():

--- a/cas/tests/test_views.py
+++ b/cas/tests/test_views.py
@@ -1,4 +1,5 @@
 from django.test import TestCase, RequestFactory
+from django.test.utils import override_settings
 
 from cas.views import _redirect_url, _login_url, _logout_url, _service_url
 
@@ -23,6 +24,10 @@ class CASViewsTestCase(TestCase):
 
     def test_service_url(self):
         self.assertEqual(_service_url(self.request), 'http://signin.k-state.edu/')
+
+    @override_settings(CAS_FORCE_SSL_SERVICE_URL=True)
+    def test_service_url_forced_ssl(self):
+        self.assertEqual(_service_url(self.request), 'https://signin.k-state.edu/')
 
     def test_redirect_url(self):
         self.assertEqual(_redirect_url(self.request), '/')

--- a/cas/views.py
+++ b/cas/views.py
@@ -35,7 +35,10 @@ def _service_url(request, redirect_to=None, gateway=False):
 
     """
 
-    protocol = ('http://', 'https://')[request.is_secure()]
+    if settings.CAS_FORCE_SSL_SERVICE_URL:
+        protocol = 'https://'
+    else:
+        protocol = ('http://', 'https://')[request.is_secure()]
     host = request.get_host()
     service = protocol + host + request.path
     if redirect_to:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,1 @@
 factory_boy
-mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 factory_boy
+mock

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,7 +2,6 @@
 
 import os, sys
 from django.conf import settings
-from django.test.utils import get_runner
 import django
 
 DIRNAME = os.path.dirname(__file__)
@@ -52,6 +51,7 @@ try:
     from django.test.simple import DjangoTestSuiteRunner
     test_runner = DjangoTestSuiteRunner(verbosity=1)
 except ImportError:
+    from django.test.utils import get_runner
     TestRunner = get_runner(settings)
     test_runner = TestRunner()
 failures = test_runner.run_tests(['cas', ])

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,6 +2,7 @@
 
 import os, sys
 from django.conf import settings
+from django.test.utils import get_runner
 import django
 
 DIRNAME = os.path.dirname(__file__)
@@ -47,8 +48,12 @@ try:
 except AttributeError:
     pass
 
-from django.test.simple import DjangoTestSuiteRunner
-test_runner = DjangoTestSuiteRunner(verbosity=1)
+try:
+    from django.test.simple import DjangoTestSuiteRunner
+    test_runner = DjangoTestSuiteRunner(verbosity=1)
+except ImportError:
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
 failures = test_runner.run_tests(['cas', ])
 if failures:
     sys.exit(failures)


### PR DESCRIPTION
Our CAS server is configured to only accept service urls over SSL. I added a setting that can ensure CAS will only return to the login view via HTTPS. I also fixed up the test runner for Django 1.8. 