### PR TITLE
Fixed validation error for non-proxied CAS tickets

### DIFF
--- a/cas/backends.py
+++ b/cas/backends.py
@@ -65,7 +65,7 @@ def _verify_cas2(ticket, service):
     :param: ticket
     :param: service
     """
-    return _internal_verify_cas(ticket, service, 'proxyValidate')
+    return _internal_verify_cas(ticket, service, 'serviceValidate')
 
 
 def _verify_cas3(ticket, service):


### PR DESCRIPTION
When trying to use this django app I always got the error "Forbidden - Login failed." The reason was that to validate a regular CAS ticket the URL suffix "/proxyValidate" was used instead of "/serviceValidate". I changed this back in my fork, but I have not tested how this change affects CAS proxying (I expect it does not, since the proxy ticket validation happens in another function).