### PR TITLE
Provide service as get parameter instead of url

### DIFF
--- a/cas/views.py
+++ b/cas/views.py
@@ -143,7 +143,7 @@ def _logout_url(request, next_page=None):
     if next_page and getattr(settings, 'CAS_PROVIDE_URL_TO_LOGOUT', True):
         protocol = ('http://', 'https://')[request.is_secure()]
         host = request.get_host()
-        url += '?' + urlencode({'url': protocol + host + next_page})
+        url += '?' + urlencode({'service': protocol + host + next_page})
 
     return url
 


### PR DESCRIPTION
As far as I known the GET parameter should be service instead of url.
Implementation like mama_cas depends on it, else a redirect is not working after logout.