### PR TITLE
Add support for protocol-rooted URL as "next_page" argument for _logout_url constructor

### DIFF
--- a/cas/views.py
+++ b/cas/views.py
@@ -141,9 +141,12 @@ def _logout_url(request, next_page=None):
     url = urlparse.urljoin(settings.CAS_SERVER_URL, 'logout')
 
     if next_page and getattr(settings, 'CAS_PROVIDE_URL_TO_LOGOUT', True):
-        protocol = ('http://', 'https://')[request.is_secure()]
-        host = request.get_host()
-        url += '?' + urlencode({'service': protocol + host + next_page})
+        if len(next_page.split(':')) > 1: #If next_page is a protocol-rooted url, skip redirect url construction 
+            url += '?' + urlencode({'service': next_page})
+        else:
+            protocol = ('http://', 'https://')[request.is_secure()]
+            host = request.get_host()
+            url += '?' + urlencode({'service': protocol + host + next_page})
 
     return url
 
@@ -254,4 +257,3 @@ def proxy_callback(request):
         ))
         return HttpResponse('PGT storage failed for {request}'.format(request=str(request.GET)),
                             content_type="text/plain")
-

--- a/cas/views.py
+++ b/cas/views.py
@@ -141,7 +141,8 @@ def _logout_url(request, next_page=None):
     url = urlparse.urljoin(settings.CAS_SERVER_URL, 'logout')
 
     if next_page and getattr(settings, 'CAS_PROVIDE_URL_TO_LOGOUT', True):
-        if len(next_page.split(':')) > 1: #If next_page is a protocol-rooted url, skip redirect url construction 
+        parsed_url = urlparse.urlparse(next_page)
+        if parsed_url.scheme: #If next_page is a protocol-rooted url, skip redirect url construction
             url += '?' + urlencode({'service': next_page})
         else:
             protocol = ('http://', 'https://')[request.is_secure()]


### PR DESCRIPTION
This request adds support for passing a protocol-rooted url (http://example.com) to the _logout_url function, instead of assuming that all redirect targets are rooted to the same host as the service from which you are logging out.