### PR TITLE
Django 2.1 compatibility

### DIFF
--- a/cas/backends.py
+++ b/cas/backends.py
@@ -221,7 +221,7 @@ class CASBackend(object):
     supports_object_permissions = False
     supports_inactive_user = False
 
-    def authenticate(self, ticket, service):
+    def authenticate(self, request, ticket, service):
         """
         Verifies CAS ticket and gets or creates User object
         NB: Use of PT to identify proxy


### PR DESCRIPTION
According to the [Django 2.1 release notes](https://docs.djangoproject.com/en/2.1/releases/2.1/), `request` is now a required positional argument to the auth backend's `authenticate` method. This is a fix.