### PR TITLE
Add support for User models with renamed `username` field.

### DIFF
--- a/cas/backends.py
+++ b/cas/backends.py
@@ -234,7 +234,7 @@ class CASBackend(object):
             return None
 
         try:
-            user = User.objects.get(username__iexact=username)
+            user = User._default_manager.get_by_natural_key(username)
         except User.DoesNotExist:
             # user will have an "unusable" password
             if settings.CAS_AUTO_CREATE_USER:

--- a/cas/models.py
+++ b/cas/models.py
@@ -85,13 +85,15 @@ def get_tgt_for(user):
     if not settings.CAS_PROXY_CALLBACK:
         raise CasConfigException("No proxy callback set in settings")
 
+    username = user.get_username()
+
     try:
-        return Tgt.objects.get(username=user.username)
+        return Tgt.objects.get(username=username)
     except ObjectDoesNotExist:
         logger.warning('No ticket found for user {user}'.format(
-            user=user.username
+            user=username
         ))
-        raise CasTicketException("no ticket found for user " + user.username)
+        raise CasTicketException("no ticket found for user " + username)
 
 
 def delete_old_tickets(**kwargs):

--- a/cas/tests/test_backend.py
+++ b/cas/tests/test_backend.py
@@ -27,4 +27,4 @@ class CASBackendTest(TestCase):
 
         with self.settings(CAS_AUTO_CREATE_USER=True):
             user = backend.authenticate('fake', 'fake')
-            self.assertEquals(user.username, username)
+            self.assertEquals(user.get_username(), username)


### PR DESCRIPTION
Django supports having different field name for usernames. It's very
common to use `email` as username, and the Django framework
profived all nessesary features to do that in a convenient way,
i.e. methods to set and access those fields without knowing
their exact names.

This commit fixed the current user interaction in CAS client
to use the mentioned above methods, as it recommended by Django
core and implemented in their standard ModelBackend.