### PR TITLE
Explicitly mark auto-created users as having no password set.

### DIFF
--- a/cas/backends.py
+++ b/cas/backends.py
@@ -236,9 +236,9 @@ class CASBackend(object):
         try:
             user = User.objects.get(username__iexact=username)
         except User.DoesNotExist:
-            # user will have an "unusable" password
             if settings.CAS_AUTO_CREATE_USER:
-                user = User.objects.create_user(username, '')
+                user = User.objects.create_user(username)
+                user.set_unusable_password()
                 user.save()
             else:
                 user = None

--- a/cas/tests/factories.py
+++ b/cas/tests/factories.py
@@ -12,4 +12,4 @@ class UserFactory(factory.DjangoModelFactory):
     first_name = "new"
     last_name = "user"
     is_staff = True
-    password = factory.PostGenerationMethodCall('set_password', '1234')
+    password = factory.PostGenerationMethodCall('set_unusable_password')


### PR DESCRIPTION
Having a blank string password is not recommended for cases
when user should be explicitely marked as having no password.
This is exactly the recommended way that is used when the
authentication for the application takes place outside.